### PR TITLE
ツイート内の長いURLが枠からはみ出さないように

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -49,6 +49,9 @@ h1 {
 .tweetbox .tweet {
   white-space: pre-wrap;
 }
+.tweetbox .tweet a {
+  overflow-wrap: break-word;
+}
 
 a {
   color: gray !important;


### PR DESCRIPTION
ツイート内の長いURLが枠からはみ出さないように style.css を編集